### PR TITLE
feat: Support asynchronous test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,26 @@ void main() {
 }
 ```
 
-You can just wrap the test code with `runWithPrint(() {});` to get the `print` output.
+You can just wrap the test code with `runWithPrint(() {});` to get the `print` output. And, you can also use it in asynchronous test.
+
+```dart
+import 'package:run_with_print/run_with_print.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Check print contents', await () {
+    await runWithPrint((logs) async {
+      print('test log');
+      await Future.delayed(const Duration());
+      expect(logs[0], 'test log');
+
+      print('test message');
+      await Future.delayed(const Duration());
+      expect(logs[1], 'test message');
+    });
+  });
+}
+```
 
 ## Contributing
 

--- a/example/run_with_print_example.dart
+++ b/example/run_with_print_example.dart
@@ -4,10 +4,19 @@ import 'dart:io';
 
 import 'package:run_with_print/run_with_print.dart';
 
-void main() {
+void main() async {
   runWithPrint((logs) {
     print('test log');
     print('test message');
+    stdout.writeln('print logs length: ${logs.length}');
+    stdout.writeln(logs);
+  });
+
+  await runWithPrint((logs) async {
+    print('test log');
+    await Future.delayed(const Duration());
+    print('test message');
+    await Future.delayed(const Duration());
     stdout.writeln('print logs length: ${logs.length}');
     stdout.writeln(logs);
   });

--- a/test/run_with_print_test.dart
+++ b/test/run_with_print_test.dart
@@ -13,4 +13,16 @@ void main() {
       expect(logs[1], 'test message');
     });
   });
+
+  test('Check print contents with async', () async {
+    await runWithPrint((logs) async {
+      print('test log');
+      await Future.delayed(const Duration());
+      expect(logs[0], 'test log');
+
+      print('test message');
+      await Future.delayed(const Duration());
+      expect(logs[1], 'test message');
+    });
+  });
 }


### PR DESCRIPTION
I make the `runWithPrint` support the asynchronous test.